### PR TITLE
using otherId in OperationOutcome.issue.details

### DIFF
--- a/input/fsh/SAMLaccessToken.fsh
+++ b/input/fsh/SAMLaccessToken.fsh
@@ -29,6 +29,8 @@ Title: "AuditEvent.agent other identifiers"
 Description: "Carries other identifiers are known for an agent."
 * ^context[+].type = #element
 * ^context[=].expression = "AuditEvent.agent"
+* ^context[+].type = #element
+* ^context[=].expression = "OperationOutcome.issue.details"
 * value[x] only Identifier
 * valueIdentifier 1..1
 

--- a/input/fsh/ex-operationOutcome.fsh
+++ b/input/fsh/ex-operationOutcome.fsh
@@ -1,0 +1,14 @@
+Instance: ex-operationOutomeWithIheOtherId
+InstanceOf: OperationOutcome
+Usage: #example
+Description: """
+Example for an OperationOutcome with an IHE OtherId extension
+
+- The extension ihe-otherId can be added to the OperationOutcome to indicate the homeCommunityId which is not responding.
+"""
+* issue.severity = #warning
+* issue.code = #incomplete
+* issue.details.extension.url = "https://profiles.ihe.net/ITI/BALP/StructureDefinition/ihe-otherId"
+* issue.details.extension.valueIdentifier.type = urn:ihe:iti:xca:2010#homeCommunityId
+* issue.details.extension.valueIdentifier.value = "urn:oid:1.2.334483.3.337395864.7"
+* issue.details.text = "The community ABC did not respond"


### PR DESCRIPTION
This PR adds an example for OperationOutcome to indicate which HomeCommuntiyId the issue belongs to.

See background of discussion in https://groups.google.com/g/ititech/c/gdnPGG1TWrg/m/zyGSM69-AgAJ?utm_medium=email&utm_source=footer

The Extension ihe-otherId has been modified that OperationOutcome.issue.details is added as a possible context.

