### PR TITLE
Add support for Trace-Context

### DIFF
--- a/input/fsh/PatientCreate.fsh
+++ b/input/fsh/PatientCreate.fsh
@@ -52,16 +52,17 @@ A basic AuditEvent profile for when a RESTful Create action happens successfully
 * agent[user].network 0..0 // users are not network devices
 * agent[user].purposeOfUse MS // if the OAuth token includes a PurposeOfUse it is recorded here
 * source MS // what agent recorded the event. Likely the client or server but might be an intermediary
-* entity ^slicing.discriminator.type = #pattern
+* entity ^slicing.discriminator.type = #value
 * entity ^slicing.discriminator.path = "type"
 * entity ^slicing.rules = #open
 * entity 1..
 * entity contains 
 	transaction 0..1 and
     data 1..1
-* entity[transaction].type = BasicAuditEntityType#XrequestId
+* entity[transaction].type.system = "https://profiles.ihe.net/ITI/BALP/CodeSystem/BasicAuditEntityType"
+* entity[transaction].type from BasicAuditEntityTypesVS (required)
 * entity[transaction].what.identifier.value 1..1
-* entity[transaction].what.identifier.value ^short = "the value of X-Request-Id"
+* entity[transaction].what.identifier.value ^short = "the value of the transaction identifier"
 * entity[data].type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 // "System Object"
 * entity[data].role from RestObjectRoles (required)
 * entity[data].role 1..

--- a/input/fsh/PatientDelete.fsh
+++ b/input/fsh/PatientDelete.fsh
@@ -52,16 +52,17 @@ A basic AuditEvent profile for when a RESTful Delete action happens successfully
 * agent[user].network 0..0 // users are not network devices
 * agent[user].purposeOfUse MS // if the OAuth token includes a PurposeOfUse it is recorded here
 * source MS // what agent recorded the event. Likely the client or server but might be an intermediary
-* entity ^slicing.discriminator.type = #pattern
+* entity ^slicing.discriminator.type = #value
 * entity ^slicing.discriminator.path = "type"
 * entity ^slicing.rules = #open
 * entity 1..
 * entity contains 
 	transaction 0..1 and
     data 1..1
-* entity[transaction].type = BasicAuditEntityType#XrequestId
+* entity[transaction].type.system = "https://profiles.ihe.net/ITI/BALP/CodeSystem/BasicAuditEntityType"
+* entity[transaction].type from BasicAuditEntityTypesVS (required)
 * entity[transaction].what.identifier.value 1..1
-* entity[transaction].what.identifier.value ^short = "the value of X-Request-Id"
+* entity[transaction].what.identifier.value ^short = "the value of the transaction identifier"
 * entity[data].type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 // "System Object"
 * entity[data].role from RestObjectRoles (required)
 * entity[data].role 1..

--- a/input/fsh/PatientQuery.fsh
+++ b/input/fsh/PatientQuery.fsh
@@ -71,16 +71,17 @@ Note: the pattern defined in DICOM and IHE have the client is identified as the 
 * agent[user].network 0..0 // users are not network devices
 * agent[user].purposeOfUse MS // if the OAuth token includes a PurposeOfUse it is recorded here
 * source MS // what agent recorded the event. Likely the client or server but might be an intermediary
-* entity ^slicing.discriminator.type = #pattern
+* entity ^slicing.discriminator.type = #value
 * entity ^slicing.discriminator.path = "type"
 * entity ^slicing.rules = #open
 * entity 1..
 * entity contains 
 	transaction 0..1 and
     query 1..1
-* entity[transaction].type = BasicAuditEntityType#XrequestId
+* entity[transaction].type.system = "https://profiles.ihe.net/ITI/BALP/CodeSystem/BasicAuditEntityType"
+* entity[transaction].type from BasicAuditEntityTypesVS (required)
 * entity[transaction].what.identifier.value 1..1
-* entity[transaction].what.identifier.value ^short = "the value of X-Request-Id"
+* entity[transaction].what.identifier.value ^short = "the value of the transaction identifier"
 * entity[query].type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 // "System Object"
 * entity[query].role = http://terminology.hl7.org/CodeSystem/object-role#24 // "Query"
 * entity[query].role 1..

--- a/input/fsh/PatientRead.fsh
+++ b/input/fsh/PatientRead.fsh
@@ -58,16 +58,17 @@ A basic AuditEvent profile for when a RESTful Read action happens successfully.
 * agent[user].network 0..0 // users are not network devices
 * agent[user].purposeOfUse MS // if the OAuth token includes a PurposeOfUse it is recorded here
 * source MS // what agent recorded the event. Likely the client or server but might be an intermediary
-* entity ^slicing.discriminator.type = #pattern
+* entity ^slicing.discriminator.type = #value
 * entity ^slicing.discriminator.path = "type"
 * entity ^slicing.rules = #open
 * entity 1..
 * entity contains 
 	transaction 0..1 and
     data 1..1
-* entity[transaction].type = BasicAuditEntityType#XrequestId
+* entity[transaction].type.system = "https://profiles.ihe.net/ITI/BALP/CodeSystem/BasicAuditEntityType"
+* entity[transaction].type from BasicAuditEntityTypesVS (required)
 * entity[transaction].what.identifier.value 1..1
-* entity[transaction].what.identifier.value ^short = "the value of X-Request-Id"
+* entity[transaction].what.identifier.value ^short = "the value of the transaction identifier"
 * entity[data].type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 // "System Object"
 * entity[data].role from RestObjectRoles (required)
 * entity[data].what 1..1

--- a/input/fsh/PatientUpdate.fsh
+++ b/input/fsh/PatientUpdate.fsh
@@ -61,16 +61,17 @@ A basic AuditEvent profile for when a RESTful Update action happens successfully
 * agent[user].network 0..0 // users are not network devices
 * agent[user].purposeOfUse MS // if the OAuth token includes a PurposeOfUse it is recorded here
 * source MS // what agent recorded the event. Likely the client or server but might be an intermediary
-* entity ^slicing.discriminator.type = #pattern
+* entity ^slicing.discriminator.type = #value
 * entity ^slicing.discriminator.path = "type"
 * entity ^slicing.rules = #open
 * entity 1..
 * entity contains 
 	transaction 0..1 and
     data 1..1
-* entity[transaction].type = BasicAuditEntityType#XrequestId
+* entity[transaction].type.system = "https://profiles.ihe.net/ITI/BALP/CodeSystem/BasicAuditEntityType"
+* entity[transaction].type from BasicAuditEntityTypesVS (required)
 * entity[transaction].what.identifier.value 1..1
-* entity[transaction].what.identifier.value ^short = "the value of X-Request-Id"
+* entity[transaction].what.identifier.value ^short = "the value of the transaction identifier"
 * entity[data].type = http://terminology.hl7.org/CodeSystem/audit-entity-type#2 // "System Object"
 * entity[data].role from RestObjectRoles (required)
 * entity[data].role 1..

--- a/input/fsh/ex-patientQuery.fsh
+++ b/input/fsh/ex-patientQuery.fsh
@@ -116,7 +116,7 @@ Audit Example for a RESTful Query using GET with a patient subject, recorded by 
 - user is John Smith
 - query is for an Observation for given patient
 - patient is specified
-- X-Request-Id is specified
+- traceparent is specified
 """
 * meta.security = http://terminology.hl7.org/CodeSystem/v3-ActReason#HTEST
 * type = http://terminology.hl7.org/CodeSystem/audit-event-type#rest "Restful Operation"
@@ -148,11 +148,11 @@ Audit Example for a RESTful Query using GET with a patient subject, recorded by 
 * entity[query].description = """
 GET test.fhir.org/r4/Observation?patient=ex-patient&_lastUpdated=gt2020-11-06T21:52:30.300Z&_sort=_lastUpdated&_count=10
 Accept: application/fhir+json; fhirVersion=4.0
-X-Request-Id: cc6d168e-5871-11ec-bf63-0242ac130002
+traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 """
-* entity[query].query = "R0VUIHRlc3QuZmhpci5vcmcvcjQvT2JzZXJ2YXRpb24/cGF0aWVudD1leC1wYXRpZW50Jl9sYXN0VXBkYXRlZD1ndDIwMjAtMTEtMDZUMjE6NTI6MzAuMzAwWiZfc29ydD1fbGFzdFVwZGF0ZWQmX2NvdW50PTEwCkFjY2VwdDogYXBwbGljYXRpb24vZmhpcitqc29uOyBmaGlyVmVyc2lvbj00LjAKWC1SZXF1ZXN0LUlkOiBjYzZkMTY4ZS01ODcxLTExZWMtYmY2My0wMjQyYWMxMzAwMDI="
-* entity[transaction].type = BasicAuditEntityType#XrequestId
-* entity[transaction].what.identifier.value = "cc6d168e-5871-11ec-bf63-0242ac130002"
+* entity[query].query = "R0VUIHRlc3QuZmhpci5vcmcvcjQvT2JzZXJ2YXRpb24/cGF0aWVudD1leC1wYXRpZW50Jl9sYXN0VXBkYXRlZD1ndDIwMjAtMTEtMDZUMjE6NTI6MzAuMzAwWiZfc29ydD1fbGFzdFVwZGF0ZWQmX2NvdW50PTEwCkFjY2VwdDogYXBwbGljYXRpb24vZmhpcitqc29uOyBmaGlyVmVyc2lvbj00LjAKdHJhY2VwYXJlbnQ6IDAwLTBhZjc2NTE5MTZjZDQzZGQ4NDQ4ZWIyMTFjODAzMTljLWI3YWQ2YjcxNjkyMDMzMzEtMDE="
+* entity[transaction].type = BasicAuditEntityType#Traceparent
+* entity[transaction].what.identifier.value = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
 
 
 

--- a/input/fsh/terms.fsh
+++ b/input/fsh/terms.fsh
@@ -1,5 +1,5 @@
 // This FSH file contains vocabulary unique to BasicAudit, that is used by many profiles. 
-// Some vocabulary are specific to one profile, and is thus defiend with that profile.
+// Some vocabulary are specific to one profile, and is thus defined with that profile.
 
 CodeSystem: BasicAuditEntityType
 Title: "Entity Types that are defined in IHE BasicAudit"
@@ -9,6 +9,8 @@ These are new codes used in BasicAudit IG, where AuditEvent.entity is used to ho
 * ^caseSensitive = true
 * ^experimental = false
 * #XrequestId "transport specific unique identifier where http X-Request-Id is used"
+* #Traceparent "transport specific unique identifier where http traceparent is used"
+* #Tracestate "transport specific unique identifier where http tracestate is used"
 
 
 

--- a/input/pagecontent/AuditEvent-ex-auditBasicQueryGetClient-intro.md
+++ b/input/pagecontent/AuditEvent-ex-auditBasicQueryGetClient-intro.md
@@ -8,12 +8,12 @@ Audit Example for a RESTful Query using GET with a patient subject, recorded by 
 - user is John Smith
 - query is for an Observation for given patient
 - patient is specified
-- X-Request-Id is specified 
+- traceparent is specified
 
 The http GET requested
 
 ```
 GET test.fhir.org/r4/Observation?patient=ex-patient&_lastUpdated=gt2020-11-06T21:52:30.300Z&_sort=_lastUpdated&_count=10
 Accept: application/fhir+json; fhirVersion=4.0
-X-Request-Id: cc6d168e-5871-11ec-bf63-0242ac130002
+traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 ```

--- a/input/pagecontent/content.md
+++ b/input/pagecontent/content.md
@@ -30,9 +30,13 @@ Execute (search and query) | [Query](StructureDefinition-IHE.BasicAudit.Query.ht
 
 An example of an auditable event being recorded by the client and server is represented by the Create examples. 
 
-#### 3:5.7.3.1 X-Request-Id header 
+#### 3:5.7.3.1 Transaction identifiers
 
-Where it is known that an http RESTful transaction included an X-Request-Id, that value should be recorded in an .entity dedicated to X-Request-Id. This ID can be used to correlated AuditEvents from client and server, and may aid with correlation on further activities recorded caused by the transaction. This means that the .entity holding the X-Request-Id may appear in AuditEvents beyond those defined here.
+When a transaction contains an identifier (such as the `X-Request-Id` and `traceparent`/`tracestate` HTTP headers), that
+value should be recorded in an .entity dedicated to transaction identifiers. This ID can be used to correlated
+AuditEvents from client and server, and may aid with correlation on further activities recorded caused by the
+transaction. This means that the .entity holding the transaction identifier may appear in AuditEvents beyond those 
+defined here.
 
 ### 3:5.7.4 SAML Security Token
 


### PR DESCRIPTION
Closes #94

## 📑 Description
This PR adds two codes to the `BasicAuditEntityType` CodeSystem and the `BasicAuditEntityTypesVS` ValueSet: `Traceparent` and `Tracestate`. The slicing is updated, an exemple is modified to use traceparent instead of XrequestId and the documentation is updated accordingly.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->